### PR TITLE
docs: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+* @strangelove-ventures/all-write


### PR DESCRIPTION
This adds the GitHub CODEOWNERS file to the repo and configures the `all-write` team as maintainers