### PR TITLE
docs: update CODEOWNERS file to use the eng-general-maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
-* @strangelove-ventures/all-write
+* @strangelove-ventures/eng-general-maintainers


### PR DESCRIPTION
Update CODEOWNERS to use the engineering general maintainers team so that way the entire org is not getting alerts for activity in the OSS template repo.

At the same time I have adjusted the settings on the `eng-general-maintainers` team so that for each PR a random member of the team will be selected for code review. When a member from the team is selected it will only send notifications to the selected team member instead of the entire team. We will make use of the `load balance` algorithm which attempts to balance the load across the entire team by taking in account the current number of PRs assigned to each member of the team. see: https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#routing-algorithms

Closes #27 