### PR TITLE
fix: goreleaser groups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     tags:
       - "*"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ changelog:
       regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
       order: 0
     - title: "Bug fixes"
-      regexp: '^.*?bug(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?(bug|fix)(\([[:word:]]+\))??!?:.+$'
       order: 1
     - title: Others
       order: 999


### PR DESCRIPTION
Fixes regex to pick up commits prefixed with either:
- bug
- fix

Additionally prevents the go releaser from running inside of pull requests. It kept erroring out due to git history & tags not matching between main and feature branches.