### PR TITLE
docs: use absolute link for security reporting help

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 The Strangelove team and the IBC community take security issues seriously. We appreciate your efforts to responsibly disclose your findings, and we will make all reasonable efforts to acknowledge your contributions.
 
-To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](security/advisories/new) tab. Please provide any data you have, and the more you can provide the more rapidly we can respond. However, do not let lack of knowledge delay your report. You may leave blank any areas of the security advisory except the detailed description of the issue, the steps to reproduce, and the version or versions you know to be affected.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability) tab. Please provide any data you have, and the more you can provide the more rapidly we can respond. However, do not let lack of knowledge delay your report. You may leave blank any areas of the security advisory except the detailed description of the issue, the steps to reproduce, and the version or versions you know to be affected.
 
 The Strangelove team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance. We may also coordinate with Amulet or other security consultants in the Cosmos/IBC space. 
 


### PR DESCRIPTION
fixed #40 