### PR TITLE
ci: implement PAT for private repos

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,7 @@ concurrency:
 
 env:
   GO_VERSION: 1.21
+  READ_PAT: ${{ secrets.ORG_READ_PAT }}
 
 jobs:
 
@@ -29,11 +30,17 @@ jobs:
       name: tidy
       steps:
       - uses: actions/checkout@v4
+      
       - name: Setup go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - run: |
+
+      - name: Configure git to use PAT for reading private repositories
+        run: git config --global url."https://${{ env.READ_PAT }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+      
+      - name: Go Mod Tidy
+        run: |
           go mod tidy
           CHANGES_IN_REPO=$(git status --porcelain)
           if [[ -n "$CHANGES_IN_REPO" ]]; then
@@ -48,11 +55,17 @@ jobs:
     name: build
     steps:
       - uses: actions/checkout@v4
+      
       - name: Setup go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - run: go build ./...
+
+      - name: Configure git to use PAT for reading private repositories
+        run: git config --global url."https://${{ env.READ_PAT }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
+      - name: Go Build
+        run: go build ./...
 
   # Run all standard, go tests
   test:
@@ -63,7 +76,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+      
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Test
+
+      - name: Configure git to use PAT for reading private repositories
+        run: git config --global url."https://${{ env.READ_PAT }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+      
+      - name: Go Test
         run: go test ./...

--- a/.github/workflows/interchain-tests.yml
+++ b/.github/workflows/interchain-tests.yml
@@ -9,23 +9,30 @@ on:
         branches: [ main ]
     pull_request:
 
+env:
+  GO_VERSION: 1.21
+  READ_PAT: ${{ secrets.ORG_READ_PAT }}
+
 jobs:
     interchain-tests:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                # list names of `make` commands to run e2e tests on
+                # list names of `make` targets to run e2e tests on
                 test:
                   - ictest-cosmos-chain
             fail-fast: false
         steps:
-            - name: Set up Go 1.21
+            - name: Set up Go
               uses: actions/setup-go@v5
               with:
-                go-version: 1.21
+                go-version: ${{ env.GO_VERSION }}
             
             - name: checkout chain
               uses: actions/checkout@v4
+
+            - name: Configure git to use PAT for reading private repositories
+              run: git config --global url."https://${{ env.READ_PAT }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
             - name: run test
               run: make ${{ matrix.test }}


### PR DESCRIPTION
Makes use of a PAT (personal access token) to access the organization's private repositories. I will add documentation for this in #39. I have tested the PAT on Cronmos here: https://github.com/strangelove-ventures/cronmos/actions/workflows/interchain-tests.yml

Previously, the test failed because it was not able to download the private Golang dependencies. Now, it's only failing because the interchaintest is not passing. It is successfully able to download the private Golang repos.