### PR TITLE
ci: update Go version to 1.23 & update golangci-lint version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.21
+  GO_VERSION: 1.23
   READ_PAT: ${{ secrets.ORG_READ_PAT }}
 
 jobs:

--- a/.github/workflows/interchain-tests.yml
+++ b/.github/workflows/interchain-tests.yml
@@ -10,7 +10,7 @@ on:
     pull_request:
 
 env:
-  GO_VERSION: 1.21
+  GO_VERSION: 1.23
   READ_PAT: ${{ secrets.ORG_READ_PAT }}
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.21
+  GO_VERSION: 1.23
 
 jobs:
   golangci:
@@ -30,5 +30,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.1.1
         with:
-          version: v1.57.2
+          version: v1.61.0
           args: --timeout 15m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: 1.21
+  GO_VERSION: 1.23
 
 jobs:
   goreleaser:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
   - asciicheck
   - bidichk
   - bodyclose
+  - copyloopvar
   - decorder
   - dupl
   - dupword
@@ -17,7 +18,6 @@ linters:
   - errchkjson
   - errname
   - exhaustive
-  - exportloopref
   - forbidigo
   - gci
   - goconst

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 golangci_lint_cmd=golangci-lint
-golangci_version=v1.57.2
+golangci_version=v1.61.1
 gofumpt_cmd=gofumpt
-gofumpt_version=v0.6.0
+gofumpt_version=v0.7.0
 
 default: help
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strangelove-ventures/oss-repo-template
 
-go 1.21.0
+go 1.23
 
 require (
 	github.com/cosmos/cosmos-sdk v0.47.11-0.20240417094812-f556fd956fb1


### PR DESCRIPTION
This PR updates the Go version to 1.23 in the `go.mod` as well as all the GitHub workflow files. It also updates the golangci-lint version.

Closes #51
Closes #52 
Closes #54 